### PR TITLE
Adding support for --watchAll

### DIFF
--- a/setup.js
+++ b/setup.js
@@ -10,9 +10,14 @@ const mongod = new MongodbMemoryServer.default({
   binary: {
     version: '3.2.18'
   }
+  autoStart: false,
 });
 
-module.exports = async function() {
+module.exports = async () => {
+  if (!mongod.isRunning) {
+    await mongod.start();
+  }
+
   const mongoConfig = {
     mongoDBName: 'jest',
     mongoUri: await mongod.getConnectionString()


### PR DESCRIPTION
## Summary

Adding support for `--watchAll`

## Test plan

run: `jest --watchAll`

After first test press Enter to run the test again. It will be fail and show this error:

> Error: Database instance is not running. You should start database by calling start() method. BTW it should start automatically if opts.autoStart!=false. Also you may provide opts.debug=true for more info.